### PR TITLE
EC-985 There is no try

### DIFF
--- a/NICE.Identity.Authentication.Sdk/Extensions/ServiceCollectionExtensions.cs
+++ b/NICE.Identity.Authentication.Sdk/Extensions/ServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ namespace NICE.Identity.Authentication.Sdk.Extensions
             services.TryAddScoped<IApiToken, ApiToken>();
             services.AddHttpContextAccessor();
             services.AddSingleton<IAuthenticationConnection, HttpClientAuthenticationConnection>();
-            services.AddSingleton<IApiTokenClient, ApiTokenClient>();
+            services.TryAddSingleton<IApiTokenClient, ApiTokenClient>();
 
 			if (authConfiguration.RedisConfiguration != null && authConfiguration.RedisConfiguration.Enabled)
 			{


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/EC-985

Without the Try the AddSingleton overrides the registration of another class for the IAPITokenClient interface. This basically makes adding a fake ApiTokenClient impossible.
The Try will register the real ApiTokenClient class for that interface _if it doesn't already exist_ - which it does if a client (like comment collection) has it's own fake implementation - which it's likely to do so that tests don't really try and get a token from real idam/auth0.